### PR TITLE
Make sure to use new props when regenerating queries

### DIFF
--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -112,7 +112,7 @@ export function pureFinalPropsSelectorFactory(
     function handleSubsequentCalls(realm, nextOwnProps) {
         const propsChanged = !areOwnPropsEqual(nextOwnProps, ownProps);
         if (propsChanged && mapPropsToQueries.dependsOnOwnProps) {
-            setupQueries(mapPropsToQueries(realm, ownProps));
+            setupQueries(mapPropsToQueries(realm, nextOwnProps));
         }
         ownProps = nextOwnProps;
 


### PR DESCRIPTION
When setting up the new queries from props we were actually passing the old queries back which was no bueno.